### PR TITLE
Seed library given file containing external track IDs

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dist/
 .linaria-cache/
 /.idea/
+/cache/

--- a/app/babel.config.json
+++ b/app/babel.config.json
@@ -15,12 +15,7 @@
     ],
     "plugins": [
         "@babel/plugin-proposal-numeric-separator",
-        [
-            "@babel/plugin-proposal-class-properties",
-            {
-                "loose": true
-            }
-        ],
+        ["@babel/plugin-proposal-class-properties"],
         "react-hot-loader/babel"
     ]
 }

--- a/app/librarySeed.json
+++ b/app/librarySeed.json
@@ -1,0 +1,3 @@
+{
+    "externalTrackIds": ["dz:702608072"]
+}

--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
     "dependencies": {
         "@types/sqlstring": "^2.2.1",
         "axios": "^0.19.2",
+        "axios-cache-adapter": "^2.5.0",
         "egoroof-blowfish": "^2.2.1",
         "express": "^4.17.1",
         "howler": "^2.1.3",

--- a/app/src/backend/index.ts
+++ b/app/src/backend/index.ts
@@ -36,7 +36,7 @@ async function main(): Promise<AddressInfo> {
     const deezerApiClient = await DeezerApiClient.create({ cacheDirectory: "cache/deezer" })
     const library = new LibraryStore(db)
     const librarySeed = await loadLibrarySeed()
-    const explorer = Explorer.seeded(library, deezerApiClient, new Resolver(), librarySeed.externalTrackIds)
+    const explorer = await Explorer.seeded(library, deezerApiClient, new Resolver(), librarySeed.externalTrackIds)
 
     app.use("/library", serve(library))
     app.use("/explorer", serve(explorer))

--- a/app/src/backend/rpc/server.ts
+++ b/app/src/backend/rpc/server.ts
@@ -6,11 +6,10 @@ import express from "express"
  * Expected usage: `app.use(basePath, serve(object))`. The object may also be a promise.
  * Assumes that the express instance has json middleware.
  */
-export function serve<T>(object: T | Promise<T>) {
+export function serve<T>(object: T) {
     return express.Router().post("/:method", async (req, res) => {
         try {
-            // TODO: `object` might not be a promise. is this a performance issue?
-            const target = (await object) as any
+            const target = object as any
             const method = req.params.method
             const args = req.body as unknown[]
             if (method in target) {

--- a/app/src/frontend/library/library.tsx
+++ b/app/src/frontend/library/library.tsx
@@ -60,6 +60,14 @@ export const { Provider: ExplorerProvider, useState: useExplorerState, useDispat
             return { update, addToLibrary, unsave, setTrackRating, explorerClient }
         }, [props.backendUrl])
 
+        useEffect(() => {
+            dispatch.explorerClient.getLibrary().then(r => {
+                console.log(JSON.stringify(r))
+                // TODO: should we be populating external ID pointers too?
+                setState(s => ({ ...s, ...r }))
+            })
+        }, [dispatch])
+
         return [state, dispatch]
     },
 )

--- a/app/src/services/deezer/FilesystemAxiosCache.ts
+++ b/app/src/services/deezer/FilesystemAxiosCache.ts
@@ -15,7 +15,7 @@ export class FilesystemAxiosCache {
         return new FilesystemAxiosCache(cacheDirectory)
     }
 
-    async getItem(key: string): Promise<unknown> {
+    async getItem(key: string): Promise<object | null> {
         try {
             const filePath = this.getFilePath(key)
             const contents = await fs.readFile(filePath)

--- a/app/src/services/deezer/FilesystemAxiosCache.ts
+++ b/app/src/services/deezer/FilesystemAxiosCache.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from "fs"
+import * as path from "path"
+
+// implements https://github.com/RasCarlito/axios-cache-adapter/blob/master/src/memory.js
+/**
+ * A filesystem cache of responses to axios requests.
+ *
+ * Assumes that the specified directory contains no other files or subdirectories.
+ */
+export class FilesystemAxiosCache {
+    private constructor(private cacheDirectory: string) {}
+
+    static async open(cacheDirectory: string): Promise<FilesystemAxiosCache> {
+        await fs.mkdir(cacheDirectory, { recursive: true })
+        return new FilesystemAxiosCache(cacheDirectory)
+    }
+
+    async getItem(key: string): Promise<unknown> {
+        try {
+            const filePath = this.getFilePath(key)
+            const contents = await fs.readFile(filePath)
+            console.log(`cache hit for ${key}`)
+            return JSON.parse(contents.toString())
+        } catch (e) {
+            console.error(e)
+            if (e.code === "ENOENT") {
+                return null
+            }
+            throw e
+        }
+    }
+
+    async setItem<T>(key: string, value: T): Promise<T> {
+        try {
+            const filePath = this.getFilePath(key)
+            const data = JSON.stringify(value)
+            await fs.writeFile(filePath, data)
+            console.log(`cached ${key}`)
+            return value
+        } catch (e) {
+            console.error(`failed to cache ${key}`)
+            console.error(e)
+            throw e
+        }
+    }
+
+    async removeItem(key: string): Promise<void> {
+        const filePath = this.getFilePath(key)
+        await fs.unlink(filePath)
+    }
+
+    async clear(): Promise<void> {
+        await fs.rmdir(this.cacheDirectory, { recursive: true })
+        await fs.mkdir(this.cacheDirectory)
+    }
+
+    async length(): Promise<number> {
+        const fileNames = await fs.readdir(this.cacheDirectory)
+        return fileNames.length
+    }
+
+    async iterate<T>(fn: (value: string, key: string) => T): Promise<T[]> {
+        const fileNames = await fs.readdir(this.cacheDirectory)
+        const resultPromises = fileNames.map(async fileName => {
+            const filePath = path.join(this.cacheDirectory, fileName)
+            const fileBuffer = await fs.readFile(filePath)
+            const json = JSON.parse(fileBuffer.toString())
+            return fn(json, filePath)
+        })
+        return Promise.all(resultPromises)
+    }
+
+    private getFilePath(key: string): string {
+        // bijective sanitization function to avoid erroneous collisions
+        // TODO: may need expansion as I hit more URLs
+        const sanitised = key.replace(/_/g, "__").replace(/=/g, "==").replace(/\//g, "_").replace(/:/g, "=") + ".json"
+        return path.join(this.cacheDirectory, sanitised)
+    }
+}

--- a/app/src/services/deezer/index.test.ts
+++ b/app/src/services/deezer/index.test.ts
@@ -25,8 +25,10 @@ beforeAll(done => {
     mockDeezerServer = app.listen(0, "127.0.0.1", () => {
         const { address, port } = mockDeezerServer.address() as AddressInfo
         const baseUrl = `http://${address}:${port}`
-        deezerClient = new DeezerApiClient(globalAxios, baseUrl)
-        done()
+        DeezerApiClient.create({ apiBaseUrl: baseUrl }).then(client => {
+            deezerClient = client
+            done()
+        })
     })
 })
 

--- a/app/src/services/deezer/index.ts
+++ b/app/src/services/deezer/index.ts
@@ -13,8 +13,6 @@ type TrackResponse = typeof import("./trackResponse.json") & MaybeEntityNotFound
 type AlbumResponse = typeof import("./albumResponse.json") & MaybeEntityNotFoundResponse
 type ArtistResponse = typeof import("./artistResponse.json") & MaybeEntityNotFoundResponse
 
-const ONE_YEAR_IN_MILLIS = 1000 * 60 * 60 * 24 * 365
-
 export class DeezerApiClient implements Service {
     private constructor(private apiBaseUrl: string, private axios: AxiosInstance) {}
 
@@ -27,7 +25,7 @@ export class DeezerApiClient implements Service {
                     cacheDirectory === null
                         ? undefined
                         : setupCache({
-                              maxAge: ONE_YEAR_IN_MILLIS,
+                              maxAge: Number.POSITIVE_INFINITY,
                               store: await FilesystemAxiosCache.open(cacheDirectory),
                           }).adapter,
             }),

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -7,7 +7,8 @@
         "jsx": "react",
         "strict": true,
         "esModuleInterop": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "useDefineForClassFields": true
     },
     "include": ["./src/**/*"]
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2025,6 +2025,14 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios-cache-adapter@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/axios-cache-adapter/-/axios-cache-adapter-2.5.0.tgz#e68be61e8c1cd7f31e4e7cfcbfd0435404ae67ef"
+  integrity sha512-YcMPdMoqmSLoZx7A5YD/PdYGuX6/Y9M2tHBhaIXvXrPeGgNnbW7nb3+uArWlT53WGHLfclnu2voMmS7jGXVg6A==
+  dependencies:
+    cache-control-esm "1.0.0"
+    lodash "^4.17.11"
+
 axios@^0.19.2:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
@@ -2447,6 +2455,11 @@ cache-base@^1.0.1:
     to-object-path "^0.3.0"
     union-value "^1.0.0"
     unset-value "^1.0.0"
+
+cache-control-esm@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cache-control-esm/-/cache-control-esm-1.0.0.tgz#417647ecf1837a5e74155f55d5a4ae32a84e2581"
+  integrity sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g==
 
 cacheable-request@^6.0.0:
   version "6.1.0"


### PR DESCRIPTION
Resolves #2 

The approach here is

1. a seed file contains a list of external track IDs to add to the library on startup
2. these are looked up as normal, one at a time, using the music service APIs, except
3. we add a filesystem-based cache to the axios API client to avoid making loads of API queries on every reload of the backend